### PR TITLE
Fix exception syntax and missing import

### DIFF
--- a/custom_components/specialized_turbo/config_flow.py
+++ b/custom_components/specialized_turbo/config_flow.py
@@ -40,7 +40,7 @@ class SpecializedTurboConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             client = await establish_connection(BleakClient, ble_device, address)
             await client.disconnect()
-        except BleakError, TimeoutError:
+        except (BleakError, TimeoutError):
             return False
         return True
 

--- a/custom_components/specialized_turbo/coordinator.py
+++ b/custom_components/specialized_turbo/coordinator.py
@@ -40,7 +40,7 @@ from specialized_turbo import (
     parse_tcx_message,
 )
 from specialized_turbo.parameters import BikeParameter
-from specialized_turbo.framing import is_framed_packet, strip_clear_prefix, unpack_tcx
+from specialized_turbo.framing import is_framed_packet, unpack_tcx
 from specialized_turbo.session import TCU1Session, TCXSession, ProtocolSession
 
 _LOGGER = logging.getLogger(__name__)
@@ -64,6 +64,13 @@ _TCX_POLL_PARAMS: tuple[BikeParameter, ...] = (
     BikeParameter.MOTOR_RIDER_INPUT_POWER,
     BikeParameter.MOTOR_TEMPERATURE,
 )
+
+
+def _strip_clear_prefix(data: bytes) -> bytes:
+    """Strip f8ff system-response envelope if present."""
+    if len(data) >= 2 and data[0:2] == b"\xf8\xff":
+        return data[2:]
+    return data
 
 
 class SpecializedTurboCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
@@ -395,7 +402,7 @@ class SpecializedTurboCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
         if is_framed_packet(payload):
             payload = unpack_tcx(payload)
         # Strip f8ff system-response envelope if present
-        payload = strip_clear_prefix(payload)
+        payload = _strip_clear_prefix(payload)
         # Skip 2-byte param ID
         key_data = payload[2:]
         # Strip trailing zero padding


### PR DESCRIPTION
Fixes two issues preventing integration startup:

1. **Exception syntax error** (Line 44, config_flow.py): Changed from deprecated Python 2 syntax `except BleakError, TimeoutError:` to proper Python 3 syntax `except (BleakError, TimeoutError):`

2. **Missing import** (coordinator.py): Removed import of `strip_clear_prefix` from specialized_turbo.framing as it doesn't exist in version 0.3.0. Implemented as local utility function `_strip_clear_prefix`.

Fixes #22