### PR TITLE
Fix CI lint and validation failures

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jamie Magee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom_components/specialized_turbo/config_flow.py
+++ b/custom_components/specialized_turbo/config_flow.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+import voluptuous as vol
 from bleak import BleakClient
 from bleak.exc import BleakError
 from bleak_retry_connector import establish_connection
-import voluptuous as vol
-
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_ble_device_from_address,
@@ -18,8 +17,9 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.helpers.device_registry import format_mac
 
-from .const import CONF_PIN, DOMAIN
 from specialized_turbo import is_specialized_advertisement
+
+from .const import CONF_PIN, DOMAIN
 
 
 class SpecializedTurboConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/custom_components/specialized_turbo/coordinator.py
+++ b/custom_components/specialized_turbo/coordinator.py
@@ -17,7 +17,6 @@ import time
 from bleak import BleakClient, BleakError
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak_retry_connector import establish_connection
-
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth.active_update_coordinator import (
     ActiveBluetoothDataUpdateCoordinator,
@@ -39,14 +38,14 @@ from specialized_turbo import (
     parse_message,
     parse_tcx_message,
 )
-from specialized_turbo.parameters import BikeParameter
 from specialized_turbo.framing import (
     is_framed_packet,
     is_nak_packet,
     parse_nak_packet,
     unpack_tcx,
 )
-from specialized_turbo.session import TCU1Session, TCXSession, ProtocolSession
+from specialized_turbo.parameters import BikeParameter
+from specialized_turbo.session import ProtocolSession, TCU1Session, TCXSession
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/specialized_turbo/sensor.py
+++ b/custom_components/specialized_turbo/sensor.py
@@ -13,9 +13,9 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     CONF_ADDRESS,
-    EntityCategory,
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
+    EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -31,13 +31,13 @@ from homeassistant.helpers.device_registry import (
     format_mac,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from specialized_turbo import AssistLevel, TelemetrySnapshot
 
 from . import SpecializedTurboConfigEntry
 from .coordinator import SpecializedTurboCoordinator
-from homeassistant.helpers.typing import StateType
-
-from specialized_turbo import AssistLevel, TelemetrySnapshot
 
 PARALLEL_UPDATES = 0
 


### PR DESCRIPTION
## Summary

- add the MIT license file already declared by the README
- organize imports flagged by the latest Ruff release

## Validation

- `uvx ruff format --check custom_components/`
- `uvx ruff check custom_components/`
- `uv run pytest tests/ --cov=custom_components/specialized_turbo --cov-report=term-missing -v`
